### PR TITLE
fix: jnlp download with curl

### DIFF
--- a/build/rootfs/etc/cont-init.d/50-setup-ikvm.sh
+++ b/build/rootfs/etc/cont-init.d/50-setup-ikvm.sh
@@ -30,6 +30,7 @@ get_launch_jnlp() {
     if curl --fail -sk --cookie-jar "$temp" -XPOST "$url/cgi/login.cgi" \
           --data "name=$KVM_USER&pwd=$KVM_PASS&check=00" -o/dev/null; then
         launch_jnlp=$(curl --fail -sk --cookie "$temp" \
+            --referer "$url/cgi/url_redirect.cgi?url_name=man_ikvm" \
             "$url/cgi/url_redirect.cgi?url_name=man_ikvm&url_type=jwsk")
         test $? -eq 0 && fail=
     fi
@@ -77,7 +78,7 @@ install_ikvm_application() {
     mkdir -p "$destdir"
     cd "$destdir"
     for x in $jar $linuxlibs; do
-        curl -o $x.pack.gz "$codebase$x.pack.gz"
+        curl -ko $x.pack.gz "$codebase$x.pack.gz"
         unpack200 $x.pack.gz $x
     done
     unzip -o liblinux*.jar


### PR DESCRIPTION
Add a Referer header from the main page of the $url in curl calls. Fix ssl check with curl for jar files

This may be due to BMC/IPMI rev 03.39 which is an older version from 2015. These changes should be non breaking but I can not test.